### PR TITLE
NPE fixed when fetching nested toMany association of toOne association

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/JoinedAttributeManager.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/JoinedAttributeManager.java
@@ -1038,16 +1038,6 @@ public class JoinedAttributeManager implements Cloneable, Serializable {
                 }
             }
         }
-        // If pagination is used, the first and last rows may be missing their 1-m joined rows, so reject them from the results.
-        // This will cause them to build normally by executing a query.
-        if (this.isToManyJoin) {
-            if ((lastKey != null) && (this.baseQuery.getMaxRows() > 0)) {
-                this.dataResultsByPrimaryKey.remove(lastKey);
-            }
-            if ((firstKey != null) && (this.baseQuery.getFirstResult() > 0)) {
-                this.dataResultsByPrimaryKey.remove(firstKey);
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
NPE fixed when fetching nested toMany association of toOne association with pagination. 

Example domain:
Person lives in a city (lazy ManyToOne)
City has streets (lazy OneToMany)

Select persons and fetch cities and it's streets:
```
Query query = entityManager.createQuery("select p from Person p");
query.setHint(QueryHints.LEFT_FETCH, "p.city.streets");
```

NPE occurs in    
`ForeignReferenceMapping#prepareNestedJoinQueryClone` line
`nestedDataResults = new ArrayList(nestedDataResults);`

because `nestedDataResults` are not found by PK because they are being removed by "see changed code".

Basically, I suppose that the root problem is `isToManyJoin` attribute of JoinManager set to `true` when there are 2 joins one toMany and one toOne. Removed code should not have been called for toOne join, but now it is.

Anyway, I was not able to simulate the problem described in comment (I can't even imagine how first and last result "may be missing their joined rows"), so I believe it would be enough to just remove it. I have not created any unit test in eclipselink project because it is a bit complicated (and I am too lazy) to set up your environment...