### PR TITLE
SchemaManager.checkTableExists causes slow deployment with large databases

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/tools/schemaframework/SchemaManager.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/tools/schemaframework/SchemaManager.java
@@ -467,7 +467,7 @@ public class SchemaManager {
                 break;
             }
         }
-        String sql = "SELECT " + column + " FROM " + table.getFullName() + " WHERE " + column + " <> " + column;
+        String sql = "SELECT " + column + " FROM " + table.getFullName() + " WHERE FALSE";
         DataReadQuery query = new DataReadQuery(sql);
         query.setMaxRows(1);
         boolean loggingOff = session.isLoggingOff();


### PR DESCRIPTION
Fix of SchemaManager reading whole tables with PostgreSQL/Derby during deployment. This fix has heavy impact on deployment time when database is large.

https://bugs.eclipse.org/bugs/show_bug.cgi?id=425150

This is pull request is an ECA compliant alternative to pull request #25 